### PR TITLE
Refactors equatable implementation to use an identity operator

### DIFF
--- a/Sources/Repeat/Repeater.swift
+++ b/Sources/Repeat/Repeater.swift
@@ -187,7 +187,7 @@ open class Repeater : Equatable {
 	private var queue: DispatchQueue? = nil
 	
 	/// Unique identifier
-  @available(*, deprecated, message: "Please use the equal-to operator (==) instead")
+	@available(*, deprecated, message: "Please use the equal-to operator (==) instead")
 	public let id = UUID()
 	
 	/// Initialize a new timer.

--- a/Sources/Repeat/Repeater.swift
+++ b/Sources/Repeat/Repeater.swift
@@ -187,7 +187,8 @@ open class Repeater : Equatable {
 	private var queue: DispatchQueue? = nil
 	
 	/// Unique identifier
-	public let id: UUID = UUID()
+  @available(*, deprecated, message: "Please use the equal-to operator (==) instead")
+	public let id = UUID()
 	
 	/// Initialize a new timer.
 	///
@@ -421,6 +422,6 @@ open class Repeater : Equatable {
 	}
 	
 	public static func == (lhs: Repeater, rhs: Repeater) -> Bool {
-		return (lhs.id == rhs.id)
+		return lhs === rhs
 	}
 }

--- a/Tests/RepeatTests/RepeatTests.swift
+++ b/Tests/RepeatTests/RepeatTests.swift
@@ -154,17 +154,17 @@ class RepeatTests: XCTestCase {
 		
 		wait(for: [exp], timeout: 20)
 	}
-  
-  func test_equality() {
-    let repeater1 = Repeater(interval: .seconds(1)) { _ in XCTFail() }
-    let repeater2 = Repeater(interval: .seconds(1)) { _ in XCTFail() }
-    XCTAssertEqual(repeater1, repeater1)
-    XCTAssertEqual(repeater2, repeater2)
-    XCTAssertNotEqual(repeater1, repeater2)
-  }
 	
-    static var allTests = [
-        ("testExample", test_once),
-        ("test_equality", test_equality)
-    ]
+	func test_equality() {
+		let repeater1 = Repeater(interval: .seconds(1)) { _ in XCTFail() }
+		let repeater2 = Repeater(interval: .seconds(1)) { _ in XCTFail() }
+		XCTAssertEqual(repeater1, repeater1)
+		XCTAssertEqual(repeater2, repeater2)
+		XCTAssertNotEqual(repeater1, repeater2)
+	}
+	
+	static var allTests = [
+		("testExample", test_once),
+		("test_equality", test_equality)
+	]
 }

--- a/Tests/RepeatTests/RepeatTests.swift
+++ b/Tests/RepeatTests/RepeatTests.swift
@@ -154,8 +154,17 @@ class RepeatTests: XCTestCase {
 		
 		wait(for: [exp], timeout: 20)
 	}
+  
+  func test_equality() {
+    let repeater1 = Repeater(interval: .seconds(1)) { _ in XCTFail() }
+    let repeater2 = Repeater(interval: .seconds(1)) { _ in XCTFail() }
+    XCTAssertEqual(repeater1, repeater1)
+    XCTAssertEqual(repeater2, repeater2)
+    XCTAssertNotEqual(repeater1, repeater2)
+  }
 	
     static var allTests = [
         ("testExample", test_once),
+        ("test_equality", test_equality)
     ]
 }


### PR DESCRIPTION
The `id` property was being used to test whether two Repeater references referred to the same Repeater instance, which is exactly what the `===` identity operator does.