### PR TITLE
Avoid over resume / suspend dispatch timer

### DIFF
--- a/Sources/Repeat/Repeater.swift
+++ b/Sources/Repeat/Repeater.swift
@@ -270,9 +270,11 @@ open class Repeater : Equatable {
 	/// Destroy current timer
 	private func destroyTimer() {
 		self.timer?.setEventHandler(handler: nil)
-		//self.timer?.resume()
 		self.timer?.cancel()
-		self.timer?.resume()
+        
+		if state == .paused || state == .finished {
+			self.timer?.resume()
+		}
 	}
 	
 	/// Create and schedule a timer that will call `handler` once after the specified time.
@@ -364,9 +366,10 @@ open class Repeater : Equatable {
 	/// Pause a running timer. If timer is paused it does nothing.
 	@discardableResult
 	public func pause() -> Bool {
-		guard state != .paused else {
+		guard state != .paused && state != .finished else {
 			return false
 		}
+		
 		return self.setPause(from: self.state)
 	}
 	
@@ -417,7 +420,6 @@ open class Repeater : Equatable {
 	
 	deinit {
 		self.observers.removeAll()
-		self.pause()
 		self.destroyTimer()
 	}
 	


### PR DESCRIPTION
GCD timers can be somewhat sensitive. If you try and resume/suspend an already resumed/suspended timer, you will get a crash with a reason like:

> BUG IN CLIENT OF LIBDISPATCH: Over-resume of an object

More information: https://medium.com/@danielgalasko/a-background-repeating-timer-in-swift-412cecfd2ef9