### PR TITLE
Release 0.5.8 - Swift 4.2

### DIFF
--- a/Repeat.podspec
+++ b/Repeat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Repeat"
-  s.version      = "0.5.7"
+  s.version      = "0.5.8"
   s.summary      = "Modern NSTimer alternative in Swift"
   s.description  = <<-DESC
 	Repeat is a modern alternative to NSTimer; no strong references, multiple observers, reusable instances with start/stop/pause support in swifty syntax.
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/malcommac/Repeat.git", :tag => s.version.to_s }
   s.source_files  = "Sources/**/*"
   s.frameworks  = "Foundation"
-  s.swift_version = '4.0'
+  s.swift_version = '4.2'
 end


### PR DESCRIPTION
Remove framework warning: Conversion to Swift 4.2 is available.